### PR TITLE
Development

### DIFF
--- a/lib/screens/device_screen.dart
+++ b/lib/screens/device_screen.dart
@@ -10,7 +10,6 @@ import 'package:safe_spot/screens/widgets/device_list_widget.dart';
 import 'package:safe_spot/screens/widgets/map/device_map_widget.dart';
 import 'package:safe_spot/screens/widgets/device_stats_widget.dart';
 import 'package:safe_spot/screens/widgets/add_device_form_widget.dart';
-import 'package:safe_spot/screens/widgets/device_geofence_overlay.dart';
 import 'package:safe_spot/utils/device_utils.dart';
 
 class DeviceScreen extends StatefulWidget {
@@ -964,51 +963,41 @@ class _DeviceScreenState extends State<DeviceScreen>
   }
 
   Widget _buildMapTab() {
-    return Stack(
-      children: [
-        DeviceMapWidget(
-          mapController: _mapController,
-          devices: _devices,
-          deviceLocations: _deviceLocations,
-          selectedDeviceId: _selectedDeviceId,
-          currentPosition: _currentPosition,
-          geofences: _geofences,
-          currentGeofencePoints: _currentGeofencePoints,
-          isDrawingGeofence: _isDrawingGeofence,
-          isDragging: _isDragging,
-          draggedPointIndex: _draggedPointIndex,
-          onDeviceSelected: (deviceId) {
-            setState(() {
-              _selectedDeviceId = deviceId;
-            });
-          },
-          onCenterMapOnDevice: _centerMapOnDevice,
-          onCenterMapOnCurrentLocation: _centerMapOnCurrentLocation,
-          onMapTap: _onMapTap,
-          onMapLongPress: _onMapLongPress,
-          findDeviceById: _findDeviceById,
-        ),
-        DeviceGeofenceOverlay(
-          isDrawingGeofence: _isDrawingGeofence,
-          isDragging: _isDragging,
-          draggedPointIndex: _draggedPointIndex,
-          currentGeofencePoints: _currentGeofencePoints,
-          geofences: _geofences,
-          isLoadingGeofences: _isLoadingGeofences,
-          onStartDrawing: _startDrawingGeofence,
-          onStopDrawing: _stopDrawingGeofence,
-          onClearPoints: () {
-            setState(() {
-              _currentGeofencePoints.clear();
-              _isDragging = false;
-              _draggedPointIndex = null;
-            });
-          },
-          onLoadGeofences: _loadGeofences,
-          onToggleGeofenceStatus: _toggleGeofenceStatus,
-          onDeleteGeofence: _deleteGeofence,
-        ),
-      ],
+    return DeviceMapWidget(
+      mapController: _mapController,
+      devices: _devices,
+      deviceLocations: _deviceLocations,
+      selectedDeviceId: _selectedDeviceId,
+      currentPosition: _currentPosition,
+      geofences: _geofences,
+      currentGeofencePoints: _currentGeofencePoints,
+      isDrawingGeofence: _isDrawingGeofence,
+      isDragging: _isDragging,
+      draggedPointIndex: _draggedPointIndex,
+      isLoadingGeofences: _isLoadingGeofences,
+      onDeviceSelected: (deviceId) {
+        setState(() {
+          _selectedDeviceId = deviceId;
+        });
+      },
+      onCenterMapOnDevice: _centerMapOnDevice,
+      onCenterMapOnCurrentLocation: _centerMapOnCurrentLocation,
+      onMapTap: _onMapTap,
+      onMapLongPress: _onMapLongPress,
+      findDeviceById: _findDeviceById,
+      // Geofence control callbacks
+      onStartDrawing: _startDrawingGeofence,
+      onStopDrawing: _stopDrawingGeofence,
+      onClearPoints: () {
+        setState(() {
+          _currentGeofencePoints.clear();
+          _isDragging = false;
+          _draggedPointIndex = null;
+        });
+      },
+      onLoadGeofences: _loadGeofences,
+      onToggleGeofenceStatus: _toggleGeofenceStatus,
+      onDeleteGeofence: _deleteGeofence,
     );
   }
 

--- a/lib/screens/widgets/map/device_map_widget.dart
+++ b/lib/screens/widgets/map/device_map_widget.dart
@@ -4,7 +4,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:safe_spot/services/device_service.dart';
 import 'package:safe_spot/services/geofence_service.dart';
-import 'widgets/map_controls_panel.dart'; // Updated import
+import 'widgets/map_controls_panel.dart';
 import 'widgets/device_info_popup.dart';
 import 'widgets/map_legend_panel.dart';
 import 'widgets/device_selector_panel.dart';
@@ -161,67 +161,71 @@ class DeviceMapWidget extends StatelessWidget {
   }
 
   Widget _buildDrawingInstructions(BuildContext context) {
-    return Positioned(
-      top: 80, // Adjusted to not overlap with device selector
-      left: 16,
-      right: 80, // Leave space for map controls
-      child: Container(
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: isDragging ? Colors.orange.shade200 : Colors.orange.shade100,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(
-            color: Colors.orange.shade300,
-          ),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.1),
-              blurRadius: 8,
-              offset: const Offset(0, 2),
-            ),
-          ],
+  return Positioned(
+    top: 70, // Just below the compact device selector
+    left: 12,
+    right: 60, // Leave space for controls
+    child: Container(
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: isDragging 
+            ? Colors.orange.shade100.withOpacity(0.95) 
+            : Colors.orange.shade50.withOpacity(0.95),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(
+          color: Colors.orange.shade300.withOpacity(0.5),
+          width: 0.5,
         ),
-        child: Column(
-          children: [
-            Row(
-              children: [
-                Icon(
-                  isDragging ? Icons.touch_app : Icons.info,
-                  color: Colors.orange.shade800,
-                  size: 20,
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    isDragging
-                        ? 'Moving point ${draggedPointIndex! + 1}. Tap anywhere on map to place it.'
-                        : 'Tap to add points • Long press near a point to move it',
-                    style: TextStyle(
-                      color: Colors.orange.shade800,
-                      fontWeight: FontWeight.w500,
-                      fontSize: 13,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            if (currentGeofencePoints.isNotEmpty && !isDragging)
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 4,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Icon(
+                isDragging ? Icons.touch_app : Icons.info_outline,
+                color: Colors.orange.shade700,
+                size: 16,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
                 child: Text(
-                  '${currentGeofencePoints.length} points added • ${currentGeofencePoints.length >= 3 ? "Ready to create!" : "Need ${3 - currentGeofencePoints.length} more point(s)"}',
+                  isDragging
+                      ? 'Moving point ${draggedPointIndex! + 1}. Tap to place it.'
+                      : 'Tap to add • Long press to move points',
                   style: TextStyle(
-                    fontSize: 11,
                     color: Colors.orange.shade700,
                     fontWeight: FontWeight.w500,
+                    fontSize: 11,
                   ),
                 ),
               ),
-          ],
-        ),
+            ],
+          ),
+          if (currentGeofencePoints.isNotEmpty && !isDragging)
+            Padding(
+              padding: const EdgeInsets.only(top: 6),
+              child: Text(
+                '${currentGeofencePoints.length} points • ${currentGeofencePoints.length >= 3 ? "Ready!" : "Need ${3 - currentGeofencePoints.length} more"}',
+                style: TextStyle(
+                  fontSize: 10,
+                  color: Colors.orange.shade600,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+        ],
       ),
-    );
-  }
+    ),
+  );
+}
 
   void _fitMapToBounds() {
     final allPoints = <LatLng>[];

--- a/lib/screens/widgets/map/widgets/device_info_popup.dart
+++ b/lib/screens/widgets/map/widgets/device_info_popup.dart
@@ -24,63 +24,59 @@ class DeviceInfoPopup extends StatelessWidget {
       markers: [
         Marker(
           point: LatLng(latestLocation.latitude, latestLocation.longitude),
-          width: constraints.maxWidth > 300 ? 240 : constraints.maxWidth - 80,
-          height: 160,
-          builder: (context) => _buildPopupCard(context),
+          width: constraints.maxWidth > 300 ? 180 : constraints.maxWidth - 60,
+          height: 120,
+          builder: (context) => _buildCompactPopup(context),
         ),
       ],
     );
   }
 
-  Widget _buildPopupCard(BuildContext context) {
+  Widget _buildCompactPopup(BuildContext context) {
     return Transform.translate(
-      offset: const Offset(0, -140),
-      child: Card(
-        elevation: 12,
-        shadowColor: Colors.black38,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(16),
+      offset: const Offset(0, -110),
+      child: Container(
+        constraints: BoxConstraints(
+          maxWidth: constraints.maxWidth - 60,
+          maxHeight: 120,
         ),
-        child: Container(
-          constraints: BoxConstraints(maxWidth: constraints.maxWidth - 80),
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              colors: [
-                Colors.white,
-                Colors.grey.shade50,
-              ],
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-            ),
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: DeviceUtils.getDeviceColor(device.deviceId).withOpacity(0.3),
-              width: 2,
-            ),
+        decoration: BoxDecoration(
+          color: Colors.white.withOpacity(0.96),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: DeviceUtils.getDeviceColor(device.deviceId).withOpacity(0.2),
+            width: 1,
           ),
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                _buildDeviceHeader(context),
-                const SizedBox(height: 16),
-                ..._buildDeviceInfoItems(context),
-              ],
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.1),
+              blurRadius: 6,
+              offset: const Offset(0, 2),
             ),
+          ],
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildCompactHeader(context),
+              const SizedBox(height: 8),
+              ..._buildCompactInfoItems(context),
+            ],
           ),
         ),
       ),
     );
   }
 
-  Widget _buildDeviceHeader(BuildContext context) {
+  Widget _buildCompactHeader(BuildContext context) {
     return Row(
       children: [
         Container(
-          width: 32,
-          height: 32,
+          width: 24,
+          height: 24,
           decoration: BoxDecoration(
             gradient: LinearGradient(
               colors: [
@@ -88,38 +84,33 @@ class DeviceInfoPopup extends StatelessWidget {
                 DeviceUtils.getDeviceColor(device.deviceId).withOpacity(0.7),
               ],
             ),
-            borderRadius: BorderRadius.circular(10),
-            boxShadow: [
-              BoxShadow(
-                color: DeviceUtils.getDeviceColor(device.deviceId).withOpacity(0.3),
-                blurRadius: 6,
-                offset: const Offset(0, 3),
-              ),
-            ],
+            borderRadius: BorderRadius.circular(8),
           ),
           child: const Icon(
             Icons.smartphone,
-            size: 18,
+            size: 14,
             color: Colors.white,
           ),
         ),
-        const SizedBox(width: 12),
+        const SizedBox(width: 8),
         Expanded(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
                 device.deviceName,
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.bold,
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
                   color: Colors.grey.shade800,
+                  fontSize: 13,
                 ),
                 overflow: TextOverflow.ellipsis,
               ),
               Text(
-                'Device Information',
+                'Device Info',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
                   color: Colors.grey.shade600,
+                  fontSize: 10,
                 ),
               ),
             ],
@@ -129,50 +120,48 @@ class DeviceInfoPopup extends StatelessWidget {
     );
   }
 
-  List<Widget> _buildDeviceInfoItems(BuildContext context) {
+  List<Widget> _buildCompactInfoItems(BuildContext context) {
     List<Widget> items = [
-      _buildInfoRow(
+      _buildCompactInfoRow(
         Icons.access_time_filled,
-        'Last seen',
         DeviceUtils.formatDateSmart(latestLocation.createdAt),
         context,
       ),
-      const SizedBox(height: 8),
-      if (latestLocation.speed != null)
-        Column(
-          children: [
-            _buildInfoRow(
-              Icons.speed,
-              'Speed',
-              DeviceUtils.formatSpeed(latestLocation.speed!),
-              context,
-              valueColor: DeviceUtils.getSpeedColor(latestLocation.speed),
-            ),
-            const SizedBox(height: 8),
-          ],
+      const SizedBox(height: 4),
+    ];
+
+    if (latestLocation.speed != null) {
+      items.addAll([
+        _buildCompactInfoRow(
+          Icons.speed,
+          DeviceUtils.formatSpeed(latestLocation.speed!),
+          context,
+          valueColor: DeviceUtils.getSpeedColor(latestLocation.speed),
         ),
-      _buildInfoRow(
+        const SizedBox(height: 4),
+      ]);
+    }
+
+    items.addAll([
+      _buildCompactInfoRow(
         Icons.timeline,
-        'History',
-        '$locationCount points',
+        '$locationCount pts',
         context,
       ),
-      const SizedBox(height: 8),
-      _buildInfoRow(
+      const SizedBox(height: 4),
+      _buildCompactInfoRow(
         Icons.radio_button_checked,
-        'Status',
         device.isActive ? 'Active' : 'Inactive',
         context,
         valueColor: device.isActive ? Colors.green.shade600 : Colors.orange.shade600,
       ),
-    ];
+    ]);
 
     return items;
   }
 
-  Widget _buildInfoRow(
+  Widget _buildCompactInfoRow(
     IconData icon,
-    String label,
     String value,
     BuildContext context, {
     Color? valueColor,
@@ -181,38 +170,34 @@ class DeviceInfoPopup extends StatelessWidget {
     return Row(
       children: [
         Container(
-          width: 24,
-          height: 24,
+          width: 16,
+          height: 16,
           decoration: BoxDecoration(
             color: (valueColor ?? theme.colorScheme.primary).withOpacity(0.1),
-            borderRadius: BorderRadius.circular(6),
+            borderRadius: BorderRadius.circular(4),
           ),
           child: Icon(
             icon,
-            size: 14,
+            size: 10,
             color: valueColor ?? theme.colorScheme.primary,
           ),
         ),
-        const SizedBox(width: 12),
-        Text(
-          label,
-          style: theme.textTheme.bodySmall?.copyWith(
-            color: theme.colorScheme.onSurfaceVariant,
-            fontWeight: FontWeight.w500,
-          ),
-        ),
-        const Spacer(),
-        Container(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-          decoration: BoxDecoration(
-            color: (valueColor ?? theme.colorScheme.onSurface).withOpacity(0.1),
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: Text(
-            value,
-            style: theme.textTheme.bodySmall?.copyWith(
-              fontWeight: FontWeight.bold,
-              color: valueColor ?? theme.colorScheme.onSurface,
+        const SizedBox(width: 8),
+        Expanded(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: (valueColor ?? theme.colorScheme.onSurface).withOpacity(0.08),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Text(
+              value,
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: valueColor ?? theme.colorScheme.onSurface,
+                fontSize: 10,
+              ),
+              overflow: TextOverflow.ellipsis,
             ),
           ),
         ),

--- a/lib/screens/widgets/map/widgets/device_selector_panel.dart
+++ b/lib/screens/widgets/map/widgets/device_selector_panel.dart
@@ -21,102 +21,93 @@ class DeviceSelectorPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Positioned(
-      top: 16,
-      left: 16,
-      right: 16,
-      child: Card(
-        elevation: 8,
-        shadowColor: Colors.black26,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(20),
+      top: 12,
+      left: 12,
+      right: 80, // Leave space for map controls
+      child: Container(
+        height: 48,
+        decoration: BoxDecoration(
+          color: Colors.white.withOpacity(0.95),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: Colors.grey.shade300, width: 0.5),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.08),
+              blurRadius: 6,
+              offset: const Offset(0, 2),
+            ),
+          ],
         ),
-        child: Container(
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              colors: [
-                Colors.white,
-                Colors.grey.shade50,
-              ],
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-            ),
-            borderRadius: BorderRadius.circular(20),
-            border: Border.all(
-              color: Colors.grey.shade200,
-              width: 1,
-            ),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
-            child: Row(
-              children: [
-                Container(
-                  padding: const EdgeInsets.all(8),
-                  decoration: BoxDecoration(
-                    color: Colors.blue.shade50,
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Icon(
-                    Icons.tune,
-                    color: Colors.blue.shade600,
-                    size: 20,
-                  ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          child: Row(
+            children: [
+              Container(
+                width: 24,
+                height: 24,
+                decoration: BoxDecoration(
+                  color: Colors.blue.shade50,
+                  borderRadius: BorderRadius.circular(8),
                 ),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        'Device Filter',
-                        style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                          color: Colors.grey.shade600,
-                          fontWeight: FontWeight.w500,
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      _buildDeviceDropdown(context),
-                    ],
-                  ),
+                child: Icon(
+                  Icons.tune,
+                  color: Colors.blue.shade600,
+                  size: 14,
                 ),
-              ],
-            ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: _buildCompactDropdown(context),
+              ),
+            ],
           ),
         ),
       ),
     );
   }
 
-  Widget _buildDeviceDropdown(BuildContext context) {
+  Widget _buildCompactDropdown(BuildContext context) {
     return DropdownButtonHideUnderline(
       child: DropdownButton<String>(
         value: selectedDeviceId,
         hint: Text(
-          'Select device to view',
-          style: TextStyle(color: Colors.grey.shade600),
+          'Filter devices',
+          style: TextStyle(
+            color: Colors.grey.shade600,
+            fontSize: 13,
+            fontWeight: FontWeight.w500,
+          ),
         ),
         isExpanded: true,
-        icon: Icon(Icons.expand_more, color: Colors.grey.shade600),
+        icon: Icon(
+          Icons.expand_more,
+          color: Colors.grey.shade600,
+          size: 16,
+        ),
+        style: TextStyle(
+          color: Colors.grey.shade800,
+          fontSize: 13,
+          fontWeight: FontWeight.w500,
+        ),
         items: [
           DropdownMenuItem<String>(
             value: null,
             child: Row(
               children: [
                 Container(
-                  width: 20,
-                  height: 20,
+                  width: 14,
+                  height: 14,
                   decoration: BoxDecoration(
                     color: Colors.green.shade100,
-                    borderRadius: BorderRadius.circular(6),
+                    borderRadius: BorderRadius.circular(4),
                   ),
                   child: Icon(
                     Icons.visibility,
-                    size: 14,
+                    size: 10,
                     color: Colors.green.shade600,
                   ),
                 ),
-                const SizedBox(width: 12),
+                const SizedBox(width: 8),
                 const Text('Show all devices'),
               ],
             ),
@@ -124,7 +115,7 @@ class DeviceSelectorPanel extends StatelessWidget {
           ...devices.map(
             (device) => DropdownMenuItem<String>(
               value: device.deviceId,
-              child: _buildDeviceDropdownItem(device),
+              child: _buildCompactDeviceItem(device),
             ),
           ),
         ],
@@ -138,30 +129,23 @@ class DeviceSelectorPanel extends StatelessWidget {
     );
   }
 
-  Widget _buildDeviceDropdownItem(Device device) {
+  Widget _buildCompactDeviceItem(Device device) {
     return Row(
       children: [
         Container(
-          width: 20,
-          height: 20,
+          width: 14,
+          height: 14,
           decoration: BoxDecoration(
             color: DeviceUtils.getDeviceColor(device.deviceId),
-            borderRadius: BorderRadius.circular(6),
-            boxShadow: [
-              BoxShadow(
-                color: DeviceUtils.getDeviceColor(device.deviceId).withOpacity(0.3),
-                blurRadius: 4,
-                offset: const Offset(0, 2),
-              ),
-            ],
+            borderRadius: BorderRadius.circular(4),
           ),
           child: const Icon(
             Icons.smartphone,
-            size: 12,
+            size: 8,
             color: Colors.white,
           ),
         ),
-        const SizedBox(width: 12),
+        const SizedBox(width: 8),
         Expanded(
           child: Text(
             device.deviceName,
@@ -170,20 +154,20 @@ class DeviceSelectorPanel extends StatelessWidget {
           ),
         ),
         Container(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
           decoration: BoxDecoration(
             color: Colors.blue.shade50,
-            borderRadius: BorderRadius.circular(12),
+            borderRadius: BorderRadius.circular(8),
             border: Border.all(
               color: Colors.blue.shade200,
-              width: 1,
+              width: 0.5,
             ),
           ),
           child: Text(
             '${deviceLocations[device.deviceId]?.length ?? 0}',
             style: TextStyle(
-              fontSize: 11,
-              fontWeight: FontWeight.bold,
+              fontSize: 10,
+              fontWeight: FontWeight.w600,
               color: Colors.blue.shade700,
             ),
           ),

--- a/lib/screens/widgets/map/widgets/map_controls_panel.dart
+++ b/lib/screens/widgets/map/widgets/map_controls_panel.dart
@@ -2,12 +2,27 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:safe_spot/services/geofence_service.dart';
 
 class MapControlsPanel extends StatelessWidget {
   final MapController mapController;
   final Position? currentPosition;
   final VoidCallback onCenterMapOnCurrentLocation;
   final VoidCallback onFitMapToBounds;
+  
+  // Geofence-related properties
+  final bool isDrawingGeofence;
+  final bool isDragging;
+  final int? draggedPointIndex;
+  final List<LatLng> currentGeofencePoints;
+  final List<Geofence> geofences;
+  final bool isLoadingGeofences;
+  final VoidCallback onStartDrawing;
+  final VoidCallback onStopDrawing;
+  final VoidCallback onClearPoints;
+  final VoidCallback onLoadGeofences;
+  final Future<void> Function(String, bool) onToggleGeofenceStatus;
+  final Future<void> Function(String, int) onDeleteGeofence;
 
   const MapControlsPanel({
     Key? key,
@@ -15,6 +30,18 @@ class MapControlsPanel extends StatelessWidget {
     required this.currentPosition,
     required this.onCenterMapOnCurrentLocation,
     required this.onFitMapToBounds,
+    required this.isDrawingGeofence,
+    required this.isDragging,
+    required this.draggedPointIndex,
+    required this.currentGeofencePoints,
+    required this.geofences,
+    required this.isLoadingGeofences,
+    required this.onStartDrawing,
+    required this.onStopDrawing,
+    required this.onClearPoints,
+    required this.onLoadGeofences,
+    required this.onToggleGeofenceStatus,
+    required this.onDeleteGeofence,
   }) : super(key: key);
 
   @override
@@ -49,7 +76,61 @@ class MapControlsPanel extends StatelessWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                // Fit bounds button
+                // Geofence Controls Section
+                _buildMapControlButton(
+                  icon: Icons.layers,
+                  onPressed: () => _showGeofencesList(context),
+                  backgroundColor: Colors.indigo.shade50,
+                  iconColor: Colors.indigo.shade600,
+                  tooltip: 'Geofences list',
+                ),
+                
+                const SizedBox(height: 8),
+                
+                _buildMapControlButton(
+                  icon: isDrawingGeofence ? Icons.stop : Icons.draw,
+                  onPressed: isDrawingGeofence ? onStopDrawing : onStartDrawing,
+                  backgroundColor: isDrawingGeofence
+                      ? Colors.orange.shade100
+                      : Colors.orange.shade50,
+                  iconColor: isDrawingGeofence
+                      ? Colors.orange.shade700
+                      : Colors.orange.shade600,
+                  tooltip: isDrawingGeofence ? 'Stop drawing' : 'Draw geofence',
+                ),
+                
+                // Clear geofence points button (only show when drawing and has points)
+                if (isDrawingGeofence && currentGeofencePoints.isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  _buildMapControlButton(
+                    icon: Icons.clear,
+                    onPressed: () {
+                      onClearPoints();
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Geofence points cleared'),
+                          backgroundColor: Colors.grey,
+                        ),
+                      );
+                    },
+                    backgroundColor: Colors.red.shade50,
+                    iconColor: Colors.red.shade600,
+                    tooltip: 'Clear points',
+                  ),
+                ],
+                
+                const SizedBox(height: 12),
+                
+                // Divider
+                Container(
+                  height: 1,
+                  width: 30,
+                  color: Colors.grey.shade300,
+                ),
+                
+                const SizedBox(height: 12),
+                
+                // Map Navigation Controls Section
                 _buildMapControlButton(
                   icon: Icons.fit_screen_outlined,
                   onPressed: onFitMapToBounds,
@@ -60,7 +141,6 @@ class MapControlsPanel extends StatelessWidget {
                 
                 const SizedBox(height: 8),
                 
-                // My location button
                 _buildMapControlButton(
                   icon: Icons.my_location_outlined,
                   onPressed: onCenterMapOnCurrentLocation,
@@ -75,7 +155,6 @@ class MapControlsPanel extends StatelessWidget {
                 
                 const SizedBox(height: 8),
                 
-                // Home/center button
                 _buildMapControlButton(
                   icon: Icons.home_outlined,
                   onPressed: () {
@@ -97,18 +176,17 @@ class MapControlsPanel extends StatelessWidget {
                 
                 const SizedBox(height: 12),
                 
-                // Zoom in button
+                // Zoom Controls Section
                 _buildMapControlButton(
                   icon: Icons.add,
                   onPressed: () => _zoomIn(),
-                  backgroundColor: Colors.orange.shade50,
-                  iconColor: Colors.orange.shade600,
+                  backgroundColor: Colors.teal.shade50,
+                  iconColor: Colors.teal.shade600,
                   tooltip: 'Zoom in',
                 ),
                 
                 const SizedBox(height: 8),
                 
-                // Zoom out button
                 _buildMapControlButton(
                   icon: Icons.remove,
                   onPressed: () => _zoomOut(),
@@ -187,5 +265,214 @@ class MapControlsPanel extends StatelessWidget {
         currentZoom - 1,
       );
     }
+  }
+
+  void _showGeofencesList(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => Container(
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+        ),
+        child: DraggableScrollableSheet(
+          initialChildSize: 0.6,
+          maxChildSize: 0.9,
+          minChildSize: 0.3,
+          builder: (context, scrollController) => Container(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Handle bar
+                Center(
+                  child: Container(
+                    width: 40,
+                    height: 4,
+                    margin: const EdgeInsets.only(bottom: 16),
+                    decoration: BoxDecoration(
+                      color: Colors.grey.shade300,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
+                
+                // Header
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'Geofences',
+                      style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                    Row(
+                      children: [
+                        if (isLoadingGeofences)
+                          const Padding(
+                            padding: EdgeInsets.only(right: 8.0),
+                            child: SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            ),
+                          ),
+                        IconButton(
+                          onPressed: onLoadGeofences,
+                          icon: const Icon(Icons.refresh),
+                        ),
+                        IconButton(
+                          onPressed: () => Navigator.pop(context),
+                          icon: const Icon(Icons.close),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                
+                // Geofences list
+                Expanded(
+                  child: geofences.isEmpty
+                      ? _buildEmptyGeofenceState(context)
+                      : ListView.builder(
+                          controller: scrollController,
+                          itemCount: geofences.length,
+                          itemBuilder: (context, index) {
+                            final geofence = geofences[index];
+                            return Card(
+                              margin: const EdgeInsets.only(bottom: 8),
+                              child: ListTile(
+                                leading: Container(
+                                  width: 20,
+                                  height: 20,
+                                  decoration: BoxDecoration(
+                                    color: geofence.color,
+                                    shape: BoxShape.circle,
+                                  ),
+                                ),
+                                title: Text(geofence.name),
+                                subtitle: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      '${geofence.points.length} points • ${geofence.isActive ? "Active" : "Inactive"}',
+                                    ),
+                                    Text(
+                                      'Created: ${geofence.createdAt.day}/${geofence.createdAt.month}/${geofence.createdAt.year}',
+                                      style: TextStyle(
+                                        fontSize: 10,
+                                        color: Colors.grey.shade600,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                isThreeLine: true,
+                                trailing: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Switch(
+                                      value: geofence.isActive,
+                                      onChanged: (value) async {
+                                        await onToggleGeofenceStatus(
+                                          geofence.id,
+                                          value,
+                                        );
+                                      },
+                                    ),
+                                    IconButton(
+                                      onPressed: () async {
+                                        final confirmed = await _showDeleteConfirmation(
+                                          context,
+                                          geofence.name,
+                                        );
+                                        if (confirmed == true) {
+                                          await onDeleteGeofence(
+                                            geofence.id,
+                                            index,
+                                          );
+                                          Navigator.pop(context);
+                                        }
+                                      },
+                                      icon: const Icon(
+                                        Icons.delete,
+                                        color: Colors.red,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptyGeofenceState(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.layers_outlined,
+            size: 48,
+            color: Colors.grey.shade400,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            isLoadingGeofences
+                ? 'Loading geofences...'
+                : 'No geofences created yet',
+            style: TextStyle(
+              color: Colors.grey.shade600,
+              fontSize: 16,
+            ),
+          ),
+          if (!isLoadingGeofences) ...[
+            const SizedBox(height: 8),
+            Text(
+              'Tap the draw button to create your first geofence',
+              style: TextStyle(
+                color: Colors.grey.shade500,
+                fontSize: 12,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Future<bool?> _showDeleteConfirmation(BuildContext context, String geofenceName) {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Geofence'),
+        content: Text('Are you sure you want to delete "$geofenceName"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: TextButton.styleFrom(
+              foregroundColor: Colors.red,
+            ),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/screens/widgets/map/widgets/map_controls_panel.dart
+++ b/lib/screens/widgets/map/widgets/map_controls_panel.dart
@@ -47,162 +47,152 @@ class MapControlsPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Positioned(
-      bottom: 16,
-      right: 16,
-      child: Card(
-        elevation: 8,
-        shadowColor: Colors.black26,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(20),
+      bottom: 12,
+      right: 12,
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white.withOpacity(0.95),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: Colors.grey.shade300, width: 0.5),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.08),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
         ),
-        child: Container(
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              colors: [
-                Colors.white,
-                Colors.grey.shade50,
-              ],
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-            ),
-            borderRadius: BorderRadius.circular(20),
-            border: Border.all(
-              color: Colors.grey.shade200,
-              width: 1,
-            ),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.all(12),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                // Geofence Controls Section
-                _buildMapControlButton(
-                  icon: Icons.layers,
-                  onPressed: () => _showGeofencesList(context),
-                  backgroundColor: Colors.indigo.shade50,
-                  iconColor: Colors.indigo.shade600,
-                  tooltip: 'Geofences list',
-                ),
-                
-                const SizedBox(height: 8),
-                
-                _buildMapControlButton(
-                  icon: isDrawingGeofence ? Icons.stop : Icons.draw,
-                  onPressed: isDrawingGeofence ? onStopDrawing : onStartDrawing,
-                  backgroundColor: isDrawingGeofence
-                      ? Colors.orange.shade100
-                      : Colors.orange.shade50,
-                  iconColor: isDrawingGeofence
-                      ? Colors.orange.shade700
-                      : Colors.orange.shade600,
-                  tooltip: isDrawingGeofence ? 'Stop drawing' : 'Draw geofence',
-                ),
-                
-                // Clear geofence points button (only show when drawing and has points)
-                if (isDrawingGeofence && currentGeofencePoints.isNotEmpty) ...[
-                  const SizedBox(height: 8),
-                  _buildMapControlButton(
-                    icon: Icons.clear,
-                    onPressed: () {
-                      onClearPoints();
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                          content: Text('Geofence points cleared'),
-                          backgroundColor: Colors.grey,
-                        ),
-                      );
-                    },
-                    backgroundColor: Colors.red.shade50,
-                    iconColor: Colors.red.shade600,
-                    tooltip: 'Clear points',
-                  ),
-                ],
-                
-                const SizedBox(height: 12),
-                
-                // Divider
-                Container(
-                  height: 1,
-                  width: 30,
-                  color: Colors.grey.shade300,
-                ),
-                
-                const SizedBox(height: 12),
-                
-                // Map Navigation Controls Section
-                _buildMapControlButton(
-                  icon: Icons.fit_screen_outlined,
-                  onPressed: onFitMapToBounds,
-                  backgroundColor: Colors.purple.shade50,
-                  iconColor: Colors.purple.shade600,
-                  tooltip: 'Fit to bounds',
-                ),
-                
-                const SizedBox(height: 8),
-                
-                _buildMapControlButton(
-                  icon: Icons.my_location_outlined,
-                  onPressed: onCenterMapOnCurrentLocation,
-                  backgroundColor: currentPosition != null 
-                      ? Colors.blue.shade50 
-                      : Colors.grey.shade100,
-                  iconColor: currentPosition != null 
-                      ? Colors.blue.shade600 
-                      : Colors.grey.shade500,
-                  tooltip: 'My location',
-                ),
-                
-                const SizedBox(height: 8),
-                
-                _buildMapControlButton(
-                  icon: Icons.home_outlined,
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Geofence Controls Section
+              _buildCompactButton(
+                icon: Icons.layers,
+                onPressed: () => _showGeofencesList(context),
+                backgroundColor: Colors.indigo.shade50,
+                iconColor: Colors.indigo.shade600,
+                tooltip: 'Geofences',
+              ),
+              
+              const SizedBox(height: 6),
+              
+              _buildCompactButton(
+                icon: isDrawingGeofence ? Icons.stop : Icons.draw,
+                onPressed: isDrawingGeofence ? onStopDrawing : onStartDrawing,
+                backgroundColor: isDrawingGeofence
+                    ? Colors.orange.shade100
+                    : Colors.orange.shade50,
+                iconColor: isDrawingGeofence
+                    ? Colors.orange.shade700
+                    : Colors.orange.shade600,
+                tooltip: isDrawingGeofence ? 'Stop' : 'Draw',
+              ),
+              
+              // Clear points button (compact, only when drawing)
+              if (isDrawingGeofence && currentGeofencePoints.isNotEmpty) ...[
+                const SizedBox(height: 6),
+                _buildCompactButton(
+                  icon: Icons.clear,
                   onPressed: () {
-                    mapController.move(LatLng(8.9511, 125.5439), 13.0);
+                    onClearPoints();
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Points cleared'),
+                        duration: Duration(seconds: 1),
+                      ),
+                    );
                   },
-                  backgroundColor: Colors.green.shade50,
-                  iconColor: Colors.green.shade600,
-                  tooltip: 'Center map',
-                ),
-                
-                const SizedBox(height: 12),
-                
-                // Divider
-                Container(
-                  height: 1,
-                  width: 30,
-                  color: Colors.grey.shade300,
-                ),
-                
-                const SizedBox(height: 12),
-                
-                // Zoom Controls Section
-                _buildMapControlButton(
-                  icon: Icons.add,
-                  onPressed: () => _zoomIn(),
-                  backgroundColor: Colors.teal.shade50,
-                  iconColor: Colors.teal.shade600,
-                  tooltip: 'Zoom in',
-                ),
-                
-                const SizedBox(height: 8),
-                
-                _buildMapControlButton(
-                  icon: Icons.remove,
-                  onPressed: () => _zoomOut(),
                   backgroundColor: Colors.red.shade50,
                   iconColor: Colors.red.shade600,
-                  tooltip: 'Zoom out',
+                  tooltip: 'Clear',
                 ),
               ],
-            ),
+              
+              const SizedBox(height: 8),
+              
+              // Thin divider
+              Container(
+                height: 0.5,
+                width: 20,
+                color: Colors.grey.shade300,
+              ),
+              
+              const SizedBox(height: 8),
+              
+              // Navigation Controls
+              _buildCompactButton(
+                icon: Icons.fit_screen_outlined,
+                onPressed: onFitMapToBounds,
+                backgroundColor: Colors.purple.shade50,
+                iconColor: Colors.purple.shade600,
+                tooltip: 'Fit',
+              ),
+              
+              const SizedBox(height: 6),
+              
+              _buildCompactButton(
+                icon: Icons.my_location_outlined,
+                onPressed: onCenterMapOnCurrentLocation,
+                backgroundColor: currentPosition != null 
+                    ? Colors.blue.shade50 
+                    : Colors.grey.shade100,
+                iconColor: currentPosition != null 
+                    ? Colors.blue.shade600 
+                    : Colors.grey.shade500,
+                tooltip: 'Location',
+              ),
+              
+              const SizedBox(height: 6),
+              
+              _buildCompactButton(
+                icon: Icons.home_outlined,
+                onPressed: () {
+                  mapController.move(LatLng(8.9511, 125.5439), 13.0);
+                },
+                backgroundColor: Colors.green.shade50,
+                iconColor: Colors.green.shade600,
+                tooltip: 'Home',
+              ),
+              
+              const SizedBox(height: 8),
+              
+              // Divider
+              Container(
+                height: 0.5,
+                width: 20,
+                color: Colors.grey.shade300,
+              ),
+              
+              const SizedBox(height: 8),
+              
+              // Zoom Controls
+              _buildCompactButton(
+                icon: Icons.add,
+                onPressed: () => _zoomIn(),
+                backgroundColor: Colors.teal.shade50,
+                iconColor: Colors.teal.shade600,
+                tooltip: 'Zoom+',
+              ),
+              
+              const SizedBox(height: 6),
+              
+              _buildCompactButton(
+                icon: Icons.remove,
+                onPressed: () => _zoomOut(),
+                backgroundColor: Colors.red.shade50,
+                iconColor: Colors.red.shade600,
+                tooltip: 'Zoom-',
+              ),
+            ],
           ),
         ),
       ),
     );
   }
 
-  Widget _buildMapControlButton({
+  Widget _buildCompactButton({
     required IconData icon,
     required VoidCallback onPressed,
     required Color backgroundColor,
@@ -211,35 +201,26 @@ class MapControlsPanel extends StatelessWidget {
   }) {
     return Tooltip(
       message: tooltip,
-      child: Container(
-        width: 48,
-        height: 48,
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: onPressed,
-            borderRadius: BorderRadius.circular(14),
-            child: Container(
-              decoration: BoxDecoration(
-                color: backgroundColor,
-                borderRadius: BorderRadius.circular(14),
-                border: Border.all(
-                  color: iconColor.withOpacity(0.2),
-                  width: 1,
-                ),
-                boxShadow: [
-                  BoxShadow(
-                    color: iconColor.withOpacity(0.1),
-                    blurRadius: 4,
-                    offset: const Offset(0, 2),
-                  ),
-                ],
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onPressed,
+          borderRadius: BorderRadius.circular(10),
+          child: Container(
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              color: backgroundColor,
+              borderRadius: BorderRadius.circular(10),
+              border: Border.all(
+                color: iconColor.withOpacity(0.15),
+                width: 0.5,
               ),
-              child: Icon(
-                icon,
-                color: iconColor,
-                size: 22,
-              ),
+            ),
+            child: Icon(
+              icon,
+              color: iconColor,
+              size: 18,
             ),
           ),
         ),
@@ -250,20 +231,14 @@ class MapControlsPanel extends StatelessWidget {
   void _zoomIn() {
     var currentZoom = mapController.zoom;
     if (currentZoom < 18) {
-      mapController.move(
-        mapController.center,
-        currentZoom + 1,
-      );
+      mapController.move(mapController.center, currentZoom + 1);
     }
   }
 
   void _zoomOut() {
     var currentZoom = mapController.zoom;
     if (currentZoom > 5) {
-      mapController.move(
-        mapController.center,
-        currentZoom - 1,
-      );
+      mapController.move(mapController.center, currentZoom - 1);
     }
   }
 
@@ -279,19 +254,19 @@ class MapControlsPanel extends StatelessWidget {
         ),
         child: DraggableScrollableSheet(
           initialChildSize: 0.6,
-          maxChildSize: 0.9,
+          maxChildSize: 0.85,
           minChildSize: 0.3,
           builder: (context, scrollController) => Container(
             padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                // Handle bar
+                // Compact handle
                 Center(
                   child: Container(
-                    width: 40,
-                    height: 4,
-                    margin: const EdgeInsets.only(bottom: 16),
+                    width: 32,
+                    height: 3,
+                    margin: const EdgeInsets.only(bottom: 12),
                     decoration: BoxDecoration(
                       color: Colors.grey.shade300,
                       borderRadius: BorderRadius.circular(2),
@@ -299,42 +274,45 @@ class MapControlsPanel extends StatelessWidget {
                   ),
                 ),
                 
-                // Header
+                // Compact header
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(
                       'Geofences',
-                      style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                            fontWeight: FontWeight.bold,
-                          ),
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
                     Row(
+                      mainAxisSize: MainAxisSize.min,
                       children: [
                         if (isLoadingGeofences)
-                          const Padding(
-                            padding: EdgeInsets.only(right: 8.0),
-                            child: SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            ),
+                          Container(
+                            width: 16,
+                            height: 16,
+                            margin: const EdgeInsets.only(right: 8),
+                            child: const CircularProgressIndicator(strokeWidth: 2),
                           ),
                         IconButton(
                           onPressed: onLoadGeofences,
-                          icon: const Icon(Icons.refresh),
+                          icon: const Icon(Icons.refresh, size: 20),
+                          padding: const EdgeInsets.all(8),
+                          constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
                         ),
                         IconButton(
                           onPressed: () => Navigator.pop(context),
-                          icon: const Icon(Icons.close),
+                          icon: const Icon(Icons.close, size: 20),
+                          padding: const EdgeInsets.all(8),
+                          constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
                         ),
                       ],
                     ),
                   ],
                 ),
-                const SizedBox(height: 16),
+                const SizedBox(height: 12),
                 
-                // Geofences list
+                // Compact geofences list
                 Expanded(
                   child: geofences.isEmpty
                       ? _buildEmptyGeofenceState(context)
@@ -344,45 +322,50 @@ class MapControlsPanel extends StatelessWidget {
                           itemBuilder: (context, index) {
                             final geofence = geofences[index];
                             return Card(
-                              margin: const EdgeInsets.only(bottom: 8),
-                              child: ListTile(
-                                leading: Container(
-                                  width: 20,
-                                  height: 20,
-                                  decoration: BoxDecoration(
-                                    color: geofence.color,
-                                    shape: BoxShape.circle,
-                                  ),
-                                ),
-                                title: Text(geofence.name),
-                                subtitle: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
+                              margin: const EdgeInsets.only(bottom: 6),
+                              elevation: 1,
+                              child: Padding(
+                                padding: const EdgeInsets.all(12),
+                                child: Row(
                                   children: [
-                                    Text(
-                                      '${geofence.points.length} points • ${geofence.isActive ? "Active" : "Inactive"}',
-                                    ),
-                                    Text(
-                                      'Created: ${geofence.createdAt.day}/${geofence.createdAt.month}/${geofence.createdAt.year}',
-                                      style: TextStyle(
-                                        fontSize: 10,
-                                        color: Colors.grey.shade600,
+                                    Container(
+                                      width: 16,
+                                      height: 16,
+                                      decoration: BoxDecoration(
+                                        color: geofence.color,
+                                        shape: BoxShape.circle,
                                       ),
                                     ),
-                                  ],
-                                ),
-                                isThreeLine: true,
-                                trailing: Row(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
+                                    const SizedBox(width: 12),
+                                    Expanded(
+                                      child: Column(
+                                        crossAxisAlignment: CrossAxisAlignment.start,
+                                        children: [
+                                          Text(
+                                            geofence.name,
+                                            style: const TextStyle(
+                                              fontWeight: FontWeight.w500,
+                                              fontSize: 14,
+                                            ),
+                                          ),
+                                          Text(
+                                            '${geofence.points.length} pts • ${geofence.isActive ? "Active" : "Inactive"}',
+                                            style: TextStyle(
+                                              fontSize: 11,
+                                              color: Colors.grey.shade600,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
                                     Switch(
                                       value: geofence.isActive,
                                       onChanged: (value) async {
-                                        await onToggleGeofenceStatus(
-                                          geofence.id,
-                                          value,
-                                        );
+                                        await onToggleGeofenceStatus(geofence.id, value);
                                       },
+                                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                                     ),
+                                    const SizedBox(width: 4),
                                     IconButton(
                                       onPressed: () async {
                                         final confirmed = await _showDeleteConfirmation(
@@ -390,17 +373,13 @@ class MapControlsPanel extends StatelessWidget {
                                           geofence.name,
                                         );
                                         if (confirmed == true) {
-                                          await onDeleteGeofence(
-                                            geofence.id,
-                                            index,
-                                          );
+                                          await onDeleteGeofence(geofence.id, index);
                                           Navigator.pop(context);
                                         }
                                       },
-                                      icon: const Icon(
-                                        Icons.delete,
-                                        color: Colors.red,
-                                      ),
+                                      icon: const Icon(Icons.delete, color: Colors.red, size: 18),
+                                      padding: const EdgeInsets.all(8),
+                                      constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
                                     ),
                                   ],
                                 ),
@@ -424,28 +403,25 @@ class MapControlsPanel extends StatelessWidget {
         children: [
           Icon(
             Icons.layers_outlined,
-            size: 48,
+            size: 40,
             color: Colors.grey.shade400,
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: 12),
           Text(
-            isLoadingGeofences
-                ? 'Loading geofences...'
-                : 'No geofences created yet',
+            isLoadingGeofences ? 'Loading...' : 'No geofences yet',
             style: TextStyle(
               color: Colors.grey.shade600,
-              fontSize: 16,
+              fontSize: 14,
             ),
           ),
           if (!isLoadingGeofences) ...[
-            const SizedBox(height: 8),
+            const SizedBox(height: 6),
             Text(
-              'Tap the draw button to create your first geofence',
+              'Tap draw to create one',
               style: TextStyle(
                 color: Colors.grey.shade500,
-                fontSize: 12,
+                fontSize: 11,
               ),
-              textAlign: TextAlign.center,
             ),
           ],
         ],
@@ -458,7 +434,7 @@ class MapControlsPanel extends StatelessWidget {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Delete Geofence'),
-        content: Text('Are you sure you want to delete "$geofenceName"?'),
+        content: Text('Delete "$geofenceName"?'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
@@ -466,9 +442,7 @@ class MapControlsPanel extends StatelessWidget {
           ),
           TextButton(
             onPressed: () => Navigator.pop(context, true),
-            style: TextButton.styleFrom(
-              foregroundColor: Colors.red,
-            ),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
             child: const Text('Delete'),
           ),
         ],

--- a/lib/screens/widgets/map/widgets/map_legend_panel.dart
+++ b/lib/screens/widgets/map/widgets/map_legend_panel.dart
@@ -28,7 +28,7 @@ class _MapLegendPanelState extends State<MapLegendPanel>
   void initState() {
     super.initState();
     _animationController = AnimationController(
-      duration: const Duration(milliseconds: 300),
+      duration: const Duration(milliseconds: 250),
       vsync: this,
     );
     _expandAnimation = CurvedAnimation(
@@ -57,54 +57,44 @@ class _MapLegendPanelState extends State<MapLegendPanel>
   @override
   Widget build(BuildContext context) {
     return Positioned(
-      bottom: 16,
-      left: 16,
+      bottom: 12,
+      left: 12,
       child: GestureDetector(
         onTap: _toggleExpanded,
-        child: Card(
-          elevation: 8,
-          shadowColor: Colors.black26,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(20),
+        child: Container(
+          constraints: BoxConstraints(
+            maxWidth: widget.constraints.maxWidth > 300 ? 200 : widget.constraints.maxWidth - 100,
           ),
-          child: Container(
-            constraints: BoxConstraints(
-              maxWidth: widget.constraints.maxWidth > 400 ? 280 : widget.constraints.maxWidth - 120,
-            ),
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                colors: [
-                  Colors.white,
-                  Colors.grey.shade50,
-                ],
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.95),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: Colors.grey.shade300, width: 0.5),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.08),
+                blurRadius: 6,
+                offset: const Offset(0, 2),
               ),
-              borderRadius: BorderRadius.circular(20),
-              border: Border.all(
-                color: Colors.grey.shade200,
-                width: 1,
-              ),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.all(20),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  _buildLegendHeader(context),
-                  SizeTransition(
-                    sizeFactor: _expandAnimation,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        const SizedBox(height: 16),
-                        ..._buildLegendItems(context),
-                      ],
-                    ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _buildCompactHeader(context),
+                SizeTransition(
+                  sizeFactor: _expandAnimation,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const SizedBox(height: 10),
+                      ..._buildCompactLegendItems(context),
+                    ],
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         ),
@@ -112,37 +102,39 @@ class _MapLegendPanelState extends State<MapLegendPanel>
     );
   }
 
-  Widget _buildLegendHeader(BuildContext context) {
+  Widget _buildCompactHeader(BuildContext context) {
     return Row(
+      mainAxisSize: MainAxisSize.min,
       children: [
         Container(
-          padding: const EdgeInsets.all(6),
+          width: 20,
+          height: 20,
           decoration: BoxDecoration(
             color: Colors.orange.shade50,
-            borderRadius: BorderRadius.circular(10),
+            borderRadius: BorderRadius.circular(6),
           ),
           child: Icon(
             Icons.map_outlined,
-            size: 16,
+            size: 12,
             color: Colors.orange.shade600,
           ),
         ),
-        const SizedBox(width: 12),
-        Expanded(
-          child: Text(
-            'Map Legend',
-            style: Theme.of(context).textTheme.titleSmall?.copyWith(
-              fontWeight: FontWeight.bold,
-              color: Colors.grey.shade700,
-            ),
+        const SizedBox(width: 8),
+        Text(
+          'Legend',
+          style: Theme.of(context).textTheme.labelLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+            color: Colors.grey.shade700,
+            fontSize: 12,
           ),
         ),
+        const SizedBox(width: 4),
         AnimatedRotation(
           turns: _isExpanded ? 0.5 : 0,
-          duration: const Duration(milliseconds: 300),
+          duration: const Duration(milliseconds: 250),
           child: Icon(
             Icons.expand_more,
-            size: 20,
+            size: 16,
             color: Colors.grey.shade600,
           ),
         ),
@@ -150,18 +142,18 @@ class _MapLegendPanelState extends State<MapLegendPanel>
     );
   }
 
-  List<Widget> _buildLegendItems(BuildContext context) {
+  List<Widget> _buildCompactLegendItems(BuildContext context) {
     List<Widget> items = [
-      _buildLegendItem(
+      _buildCompactLegendItem(
         Icons.radio_button_unchecked,
-        'Historical points',
+        'History',
         Colors.blue.shade400,
         context,
       ),
-      const SizedBox(height: 12),
-      _buildLegendItem(
+      const SizedBox(height: 8),
+      _buildCompactLegendItem(
         Icons.smartphone,
-        'Device location',
+        'Device',
         Colors.green.shade500,
         context,
       ),
@@ -169,10 +161,10 @@ class _MapLegendPanelState extends State<MapLegendPanel>
 
     if (widget.currentPosition != null) {
       items.addAll([
-        const SizedBox(height: 12),
-        _buildLegendItem(
+        const SizedBox(height: 8),
+        _buildCompactLegendItem(
           Icons.my_location,
-          'Your location',
+          'You',
           Colors.blue.shade600,
           context,
         ),
@@ -181,8 +173,8 @@ class _MapLegendPanelState extends State<MapLegendPanel>
 
     if (widget.geofences.isNotEmpty) {
       items.addAll([
-        const SizedBox(height: 12),
-        _buildLegendItem(
+        const SizedBox(height: 8),
+        _buildCompactLegendItem(
           Icons.layers_outlined,
           'Geofences',
           Colors.orange.shade500,
@@ -192,64 +184,68 @@ class _MapLegendPanelState extends State<MapLegendPanel>
     }
 
     items.addAll([
-      const SizedBox(height: 12),
-      _buildMovementPathLegend(context),
+      const SizedBox(height: 8),
+      _buildCompactPathLegend(context),
     ]);
 
     return items;
   }
 
-  Widget _buildLegendItem(IconData icon, String label, Color color, BuildContext context) {
+  Widget _buildCompactLegendItem(IconData icon, String label, Color color, BuildContext context) {
     return Row(
+      mainAxisSize: MainAxisSize.min,
       children: [
         Container(
-          width: 24,
-          height: 24,
+          width: 16,
+          height: 16,
           decoration: BoxDecoration(
             color: color.withOpacity(0.1),
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: BorderRadius.circular(4),
             border: Border.all(
               color: color.withOpacity(0.3),
-              width: 1,
+              width: 0.5,
             ),
           ),
           child: Icon(
             icon,
-            size: 14,
+            size: 10,
             color: color,
           ),
         ),
-        const SizedBox(width: 12),
+        const SizedBox(width: 8),
         Text(
           label,
-          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
             color: Colors.grey.shade700,
             fontWeight: FontWeight.w500,
+            fontSize: 11,
           ),
         ),
       ],
     );
   }
 
-  Widget _buildMovementPathLegend(BuildContext context) {
+  Widget _buildCompactPathLegend(BuildContext context) {
     return Row(
+      mainAxisSize: MainAxisSize.min,
       children: [
         Container(
-          width: 24,
-          height: 3,
+          width: 16,
+          height: 2,
           decoration: BoxDecoration(
             gradient: LinearGradient(
               colors: [Colors.blue.shade400, Colors.blue.shade600],
             ),
-            borderRadius: BorderRadius.circular(2),
+            borderRadius: BorderRadius.circular(1),
           ),
         ),
-        const SizedBox(width: 12),
+        const SizedBox(width: 8),
         Text(
-          'Movement path',
-          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+          'Path',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
             color: Colors.grey.shade700,
             fontWeight: FontWeight.w500,
+            fontSize: 11,
           ),
         ),
       ],

--- a/lib/screens/widgets/profile_info_card.dart
+++ b/lib/screens/widgets/profile_info_card.dart
@@ -61,7 +61,7 @@ class ProfileInfoCard extends StatelessWidget {
             title,
             style: TextStyle(
               fontSize: 14,
-              color: Colors.grey.shade600,
+              color: const Color.fromARGB(255, 255, 255, 255),
               fontWeight: FontWeight.w500,
             ),
           ),
@@ -71,7 +71,7 @@ class ProfileInfoCard extends StatelessWidget {
             style: const TextStyle(
               fontSize: 16,
               fontWeight: FontWeight.w600,
-              color: Color(0xFF111827),
+              color: Color.fromARGB(255, 255, 255, 255),
             ),
           ),
         ],


### PR DESCRIPTION
Remove the DeviceGeofenceOverlay from _buildMapTab() method since the controls are now integrated into the map controls panel. 
Updated DeviceMapWidget call in  _buildMapTab() method to include the geofence control callbacks
Better organization
Touch targets still accessible (minimum 36px)
All functionality preserved in smaller form factors